### PR TITLE
Fixed the indices start convention for sector, superlayer, layer, from 0 to 1:

### DIFF
--- a/clas12/alert/README.md
+++ b/clas12/alert/README.md
@@ -6,12 +6,8 @@
 cd ../targets
 ./targets.pl config.dat
 cd ../alert/ahdc
-run-groovy factory.groovy --variation default --runnumber 11
-run-groovy factory.groovy --variation rga_fall2018 --runnumber 11
 ./ahdc.pl config.dat
 cd ../atof
-run-groovy factory.groovy --variation default --runnumber 11
-run-groovy factory.groovy --variation rga_fall2018 --runnumber 11
 ./atof.pl config.dat
 cd ../external_shell_nonActif
 ./alertshell.pl config.dat

--- a/clas12/alert/atof/factory.groovy
+++ b/clas12/alert/atof/factory.groovy
@@ -54,7 +54,7 @@ for(int isec=1; isec<=nsectors; isec++)
 			{
 				writer1 << "atof.sector" << isec << ".superlayer"<< isl << ".layer"<< ilay <<".ncomponents | " << ncomponents << "| na | number of counters in module | sergeyeva | sergeyeva@ipno.in2p3.fr | none | none | 15 June 2020 \n";
 
-				for(int icomp=(isec-1)*4; icomp<(isec-1)*4+ncomponents; icomp++) 
+				for(int icomp=(isec-1)*4+1; icomp<=(isec-1)*4+ncomponents; icomp++) 
 				{
 					//println "sector = ${isec}, superlayer = ${isl}, layer = ${ilay}, icomp = ${icomp}"
 					Component comp = atof.getSector(isec).getSuperlayer(isl).getLayer(ilay).getComponent(icomp);

--- a/clas12/alert/atof/factory.groovy
+++ b/clas12/alert/atof/factory.groovy
@@ -33,25 +33,30 @@ def writer2=outFile.newWriter();
 // may want to add mother volume
 int nsectors = atof.getNumSectors();
 
+//println "Nsectors = ${nsectors}"
 
 //double ATOF_Z_length = 279.7; // mm, atof paddles total lenght in z
 
-for(int isec=0; isec<nsectors; isec++) 
+for(int isec=1; isec<=nsectors; isec++) 
 {
 	int nsuperlayers = atof.getSector(isec).getNumSuperlayers();
-	for(int isl=0; isl<nsuperlayers; isl++) 
+	//println "sector = ${isec}, nsuperlayers = ${nsuperlayers}"
+	for(int isl=1; isl<=nsuperlayers; isl++) 
 	{
 		int nlayers = atof.getSector(isec).getSuperlayer(isl).getNumLayers();
-		for(int ilay=0; ilay<nlayers; ilay++) 
+		//println "sector = ${isec}, superlayer = ${isl}, nlayers = ${nlayers}"
+		for(int ilay=1; ilay<=nlayers; ilay++) 
 		{
 			int ncomponents = atof.getSector(isec).getSuperlayer(isl).getLayer(ilay).getNumComponents();
+			//println "sector = ${isec}, superlayer = ${isl}, layer = ${ilay}, ncomponents = ${ncomponents}"
 			//if(isec==0 && isl==0 && ilay==0) writer1 << "ahdc.layer.ncomponents | " << ncomponents << "\n"; 
 			if(ncomponents!=0) 
 			{
 				writer1 << "atof.sector" << isec << ".superlayer"<< isl << ".layer"<< ilay <<".ncomponents | " << ncomponents << "| na | number of counters in module | sergeyeva | sergeyeva@ipno.in2p3.fr | none | none | 15 June 2020 \n";
 
-				for(int icomp=isec*4; icomp<isec*4+ncomponents; icomp++) 
+				for(int icomp=(isec-1)*4; icomp<(isec-1)*4+ncomponents; icomp++) 
 				{
+					//println "sector = ${isec}, superlayer = ${isl}, layer = ${ilay}, icomp = ${icomp}"
 					Component comp = atof.getSector(isec).getSuperlayer(isl).getLayer(ilay).getComponent(icomp);
 					writer2<< gemcString(isec, isl, ilay, comp);
 				}
@@ -102,16 +107,16 @@ public String gemcString(int sector, int superlayer,int layer, Component comp) {
 	double bottom_y_7 = p7.y();
 
 		// component name should be added
-        	str.append(String.format("sector%d_superlayer%d_layer%d_paddle%d | root", sector, superlayer, layer, (comp.getComponentId()+1)));
+        	str.append(String.format("sector%d_superlayer%d_layer%d_paddle%d | root", sector, superlayer, layer, (comp.getComponentId())));
 		
 		// Giving the origin point of coordinate system in which the trapezoide vertices are defined
 		//str.append(String.format("| %8.4f*mm %8.4f*mm %8.4f*mm | ", 0.0, 0.0, ((comp.getLine().midpoint().z()-15.0)-150.0+15.0))); // in mm
 		
-		if(superlayer == 0)
+		if(superlayer == 1)
 		{
 			str.append(String.format("| %8.4f*mm %8.4f*mm %8.4f*mm | ", 0.0, 0.0, ((comp.getLine().midpoint().z() - 279.7/2)))); // in mm
 		}
-		if(superlayer == 1)
+		if(superlayer == 2)
 		{
 			str.append(String.format("| %8.4f*mm %8.4f*mm %8.4f*mm | ", 0.0, 0.0, ((comp.getLine().midpoint().z() - 279.7/2)))); // in mm
 		}
@@ -127,11 +132,11 @@ public String gemcString(int sector, int superlayer,int layer, Component comp) {
 		String type = "G4GenericTrap"
         	str.append(String.format("| %8s |", type));
 		// to add the half-length in Z axis, coatjava class dimensions are in mm!
-		if(superlayer == 0)
+		if(superlayer == 1)
 		{
 			str.append(String.format(" %8.4f*mm ", 279.7/2.0));	
 		}
-		if(superlayer == 1)
+		if(superlayer == 2)
 		{
 			str.append(String.format(" %8.4f*mm ", 27.7/2.0));	
 		}
@@ -150,7 +155,7 @@ public String gemcString(int sector, int superlayer,int layer, Component comp) {
 	
 		// currently only writing the component id but should save all necessary identifiers according to detector definition
         	str.append(" | ");
-        	str.append(String.format("%d %d %d %d", sector, superlayer, layer, (comp.getComponentId()+1)));
+        	str.append(String.format("%d %d %d %d", sector, superlayer, layer, (comp.getComponentId())));
 
 		str.append("\n");
         

--- a/clas12/alert/atof/geometry_java.pl
+++ b/clas12/alert/atof/geometry_java.pl
@@ -93,7 +93,7 @@ sub build_paddles
 	#my $mother = "atof_mother";
 	my $mother = "ahdc_mother";
 	
-	for(my $n=( ($sector-1) *4); $n<( ($sector-1) *4+$npaddles); $n++)
+	for(my $n=( ($sector-1) *4)+1; $n<=( ($sector-1) *4+$npaddles); $n++)
 	{
 			my %detector = init_det();
 

--- a/clas12/alert/atof/geometry_java.pl
+++ b/clas12/alert/atof/geometry_java.pl
@@ -61,21 +61,21 @@ sub makeATOF
 sub build_sectors
 {
 	# loop for sectors
-	for(my $s=0; $s<$nsectors; $s++)
+	for(my $s=1; $s<=$nsectors; $s++)
 	{
 		# loop for superlayers in Z
-		for(my $z=0; $z<$nsuperlayers; $z++)
+		for(my $z=1; $z<=$nsuperlayers; $z++)
 		{
-			if($z == 0)
+			if($z == 1)
 			{
 				$nlayers = 1;
 			}
-			if($z == 1)
+			if($z == 2)
 			{
 				$nlayers = 10;
 			}
 			# loop for layers in XY
-			for(my $l=0; $l<$nlayers; $l++)	
+			for(my $l=1; $l<=$nlayers; $l++)	
 			{	
 				$npaddles = $main::parameters{"atof.sector$s.superlayer$z.layer$l.ncomponents"};				
 				build_paddles($s,$z,$l);
@@ -93,7 +93,7 @@ sub build_paddles
 	#my $mother = "atof_mother";
 	my $mother = "ahdc_mother";
 	
-	for(my $n=($sector*4+1); $n<=($sector*4+$npaddles); $n++)
+	for(my $n=( ($sector-1) *4); $n<( ($sector-1) *4+$npaddles); $n++)
 	{
 			my %detector = init_det();
 
@@ -106,13 +106,13 @@ sub build_paddles
 			$detector{"dimensions"}   = $dimensions->{$vname};
 			$detector{"description"}  = "ATOFpaddle$n sector$sector superlayer$superlayer layer$layer";
 
-			if($superlayer==0)
+			if($superlayer==1)
 			{
 				$detector{"color"}        = "ff11aa";
 			} 
 			else 
 			{
-				if($superlayer==1) {$detector{"color"}        = "00aa00";}
+				if($superlayer==2) {$detector{"color"}        = "00aa00";}
 			}
 
 			$detector{"material"}     = "scintillator";


### PR DESCRIPTION
Fixed the indices start convention for sector, superlayer, layer, from 0 to 1:

sector, superlayer, layer, index starting from 0 to 1, but then paddle had to start from 0:
https://github.com/gemc/detectors/commit/f125e5dfe9cf4c2a125242a4bcffef82bcbde469
Works with coatjava commit: coatjava/commit/3420bb9
Rolled back paddle indexing convention to start by 1:
https://github.com/gemc/detectors/commit/4106829ee9144b02e9240a5b2e29ecd2cb6f90ea
coatjava/commit/09cad74
Works with coatjava commit: coatjava/commit/09cad74