### PR TITLE
Create a bank for the waveform of ALERT, AHDC::wf136

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ clas12/rtpc/rtpc.pl~
 clas12/rich_sector4/
 clas12/alert/*/*.txt
 clas12/targets/*.txt
+clas12/alert/alert_clas12.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ clas12/rtpc/rtpc.pl~
 .DS_Store
 clas12/rich_sector4/
 clas12/alert/*/*.txt
+clas12/targets/*.txt

--- a/clas12/alert/ahdc/bank.pl
+++ b/clas12/alert/ahdc/bank.pl
@@ -41,22 +41,26 @@ sub define_ahdc_bank
 	insert_bank_variable(\%configuration, $bankname, "layer",        2, "Di", "hipo layer is superlayer*10 + layer");
 	insert_bank_variable(\%configuration, $bankname, "component",    3, "Di", "wire number");
 	insert_bank_variable(\%configuration, $bankname, "ADC_order",    4, "Di", "set to 1");
-	insert_bank_variable(\%configuration, $bankname, "ADC_ADC",      5, "Di", "ADC integral from pulse fit");
-	insert_bank_variable(\%configuration, $bankname, "ADC_time" ,    6, "Dd", "adc time from pulse fit");
+	insert_bank_variable(\%configuration, $bankname, "ADC_ADC",      5, "Di", "ADC integral from pulse fit - currently set to adcMax");
+	insert_bank_variable(\%configuration, $bankname, "ADC_time" ,    6, "Dd", "adc time from pulse fit - currently set to t_ovr (time over threshold i.e (adcMax + ped)/2))");
 	insert_bank_variable(\%configuration, $bankname, "ADC_ped" ,     7, "Di", "pedestal from pulse analysis - currently set to noise level");
 	insert_bank_variable(\%configuration, $bankname, "ADC_integral" ,8, "Di", "integral");
-	insert_bank_variable(\%configuration, $bankname, "ADC_timestamp",9, "Dd", "currently set to t_start");
-	insert_bank_variable(\%configuration, $bankname, "ADC_t_cfd",10, "Dd", "time from constant fraction discriminator");
-	insert_bank_variable(\%configuration, $bankname, "ADC_mctime",11, "Dd", "mc time - weighted average with Edep");
-	insert_bank_variable(\%configuration, $bankname, "ADC_nsteps",12, "Di", "nsteps");
-	insert_bank_variable(\%configuration, $bankname, "ADC_mcEtot",13, "Dd", "mcEtot");
+	insert_bank_variable(\%configuration, $bankname, "ADC_timestamp",9, "Di", "timestamp from DREAM - currently set to 0");
+        insert_bank_variable(\%configuration, $bankname, "ADC_t_start",  10, "Dd", "time when the signal reaches half of its amplitude i.e threshold i.e (adcMax + ped)/2");
+	insert_bank_variable(\%configuration, $bankname, "ADC_t_cfd",    11, "Dd", "time from constant fraction discriminator");
+	insert_bank_variable(\%configuration, $bankname, "ADC_mctime",   12, "Dd", "mc time - time deducted from doca calculation and weighted average with Edep");
+	insert_bank_variable(\%configuration, $bankname, "ADC_nsteps",   13, "Di", "nsteps");
+	insert_bank_variable(\%configuration, $bankname, "ADC_mcEtot",   14, "Dd", "mc Etot - sum of all Edep");
 	#insert_bank_variable(\%configuration, $bankname, "TDC_order",    4, "Di", "set to 0");
 	#insert_bank_variable(\%configuration, $bankname, "TDC_TDC",      5, "Di", "TDC integral from pulse fit");
 	#insert_bank_variable(\%configuration, $bankname, "TDC_ped" ,     6, "Di", "pedestal from pulse analysis - currently set to doca");
 	insert_bank_variable(\%configuration, $bankname, "hitn",        99, "Di", "hit number");
+	
+	insert_bank_variable(\%configuration, $bankname, "wf136_order",     4, "Di", "set to 1");
+        insert_bank_variable(\%configuration, $bankname, "wf136_timestamp", 5, "Di", "timestamp from DREAM - currently set to 0");
 	for my $itr (1..136) {
 		my $entry = "wf136_s$itr";
-		insert_bank_variable(\%configuration, $bankname, $entry,$itr+3, "Di", "Digitized AHDC siganl : sample n° $itr");
+		insert_bank_variable(\%configuration, $bankname, $entry,$itr+5, "Di", "ADC sample $itr");
 	}
 
 	

--- a/clas12/alert/ahdc/bank.pl
+++ b/clas12/alert/ahdc/bank.pl
@@ -50,10 +50,14 @@ sub define_ahdc_bank
 	insert_bank_variable(\%configuration, $bankname, "ADC_mctime",11, "Dd", "mc time - weighted average with Edep");
 	insert_bank_variable(\%configuration, $bankname, "ADC_nsteps",12, "Di", "nsteps");
 	insert_bank_variable(\%configuration, $bankname, "ADC_mcEtot",13, "Dd", "mcEtot");
-#	insert_bank_variable(\%configuration, $bankname, "TDC_order",    4, "Di", "set to 0");
-#	insert_bank_variable(\%configuration, $bankname, "TDC_TDC",      5, "Di", "TDC integral from pulse fit");
-#	insert_bank_variable(\%configuration, $bankname, "TDC_ped" ,     6, "Di", "pedestal from pulse analysis - currently set to doca");
-	insert_bank_variable(\%configuration, $bankname, "hitn",        99, "Di", "hit number");	
+	#insert_bank_variable(\%configuration, $bankname, "TDC_order",    4, "Di", "set to 0");
+	#insert_bank_variable(\%configuration, $bankname, "TDC_TDC",      5, "Di", "TDC integral from pulse fit");
+	#insert_bank_variable(\%configuration, $bankname, "TDC_ped" ,     6, "Di", "pedestal from pulse analysis - currently set to doca");
+	insert_bank_variable(\%configuration, $bankname, "hitn",        99, "Di", "hit number");
+	for my $itr (1..136) {
+		my $entry = "wf136_s$itr";
+		insert_bank_variable(\%configuration, $bankname, $entry,$itr+3, "Di", "Digitized AHDC siganl : sample n° $itr");
+	}
 
 	
 


### PR DESCRIPTION
Here is the modifications that I have made to manage to create a new bank, `AHDC::wf:136`, to save the waveform of the AHDC signal. This code has to be run with the corresponding pull request for `gemc/source`.

The following figures show the result.

![Screenshot from 2024-10-23 18-40-56](https://github.com/user-attachments/assets/0c1fab09-4fc8-46d1-8d2f-09eba6cf2dea)

